### PR TITLE
Centralize UI

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -20,6 +20,7 @@
     "vue": "^2.6.11",
     "vue-multiselect": "^2.1.6",
     "vue-router": "^3.5.1",
+    "vue-select": "^3.16.0",
     "vuelidate": "^0.7.6",
     "vuex": "^3.6.2"
   },

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -16,6 +16,7 @@ export default {
 <style lang="scss">
 @import '../../node_modules/bootstrap/scss/bootstrap.scss';
 @import '../../node_modules/bootstrap-vue/src/index.scss';
+@import "../../node_modules/vue-select/src/scss/vue-select.scss";
 
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -134,13 +134,14 @@ export default {
   },
   mounted() {
     document.addEventListener('keyup', this.changeSelectedGrantIndex);
-    this.paginateGrants();
+    this.setup();
   },
   computed: {
     ...mapGetters({
       grants: 'grants/grants',
       grantsPagination: 'grants/grantsPagination',
       agency: 'users/agency',
+      selectedAgency: 'users/selectedAgency',
     }),
     totalRows() {
       return this.grantsPagination ? this.grantsPagination.total : 0;
@@ -181,6 +182,9 @@ export default {
     },
   },
   watch: {
+    selectedAgency() {
+      this.setup();
+    },
     currentPage() {
       this.paginateGrants();
     },
@@ -207,6 +211,9 @@ export default {
     ...mapActions({
       fetchGrants: 'grants/fetchGrants',
     }),
+    setup() {
+      this.paginateGrants();
+    },
     titleize,
     debounceSearchInput: debounce(function bounce(newVal) {
       this.debouncedSearchInput = newVal;

--- a/packages/client/src/components/GrantsTable.vue
+++ b/packages/client/src/components/GrantsTable.vue
@@ -69,7 +69,7 @@ export default {
   props: {
     showInterested: Boolean,
     showAging: Boolean,
-    showAssignedToAgency: Number,
+    showAssignedToAgency: String,
   },
   data() {
     return {

--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -9,7 +9,7 @@
         <b-navbar-nav class="ml-auto">
 
           <b-nav-text>
-            <b-badge>{{agency ? agency.name : ''}}</b-badge>
+            <b-badge>{{selectedAgency ? selectedAgency.name : ''}}</b-badge>
           </b-nav-text>
 
           <b-nav-item-dropdown right v-if="loggedInUser">
@@ -60,6 +60,7 @@ export default {
       agency: 'users/agency',
       loggedInUser: 'users/loggedInUser',
       userRole: 'users/userRole',
+      selectedAgency: 'users/selectedAgency',
     }),
   },
   methods: {

--- a/packages/client/src/components/Layout.vue
+++ b/packages/client/src/components/Layout.vue
@@ -17,6 +17,7 @@
             <template #button-content>
               <em>{{loggedInUser.email}}</em>
             </template>
+            <b-dropdown-item-button href="#" @click="settingsClicked">Settings</b-dropdown-item-button>
             <b-dropdown-item-button href="#" @click="logout">Sign Out</b-dropdown-item-button>
           </b-nav-item-dropdown>
         </b-navbar-nav>
@@ -34,18 +35,24 @@
     <div style="margin-top: 10px">
       <router-view />
     </div>
+    <ProfileSettingsModal
+     :showModal.sync="showProfileSettingModal"/>
   </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex';
 
+import ProfileSettingsModal from '@/components/Modals/ProfileSettings.vue';
+
 export default {
   name: 'Layout',
   components: {
+    ProfileSettingsModal,
   },
   data() {
     return {
+      showProfileSettingModal: false,
     };
   },
   computed: {
@@ -61,6 +68,9 @@ export default {
       this.$store
         .dispatch('users/logout')
         .then(() => this.$router.push({ path: '/login' }));
+    },
+    settingsClicked() {
+      this.showProfileSettingModal = true;
     },
   },
 };

--- a/packages/client/src/components/Modals/GrantDetails.vue
+++ b/packages/client/src/components/Modals/GrantDetails.vue
@@ -162,6 +162,7 @@ export default {
   computed: {
     ...mapGetters({
       agency: 'users/agency',
+      selectedAgencyId: 'users/selectedAgencyId',
       agencies: 'agencies/agencies',
       users: 'users/users',
       interestedCodes: 'grants/interestedCodes',
@@ -170,13 +171,13 @@ export default {
       if (!this.selectedGrant) {
         return false;
       }
-      return this.selectedGrant.viewed_by_agencies.find((viewed) => viewed.agency_id === this.agency.id);
+      return this.selectedGrant.viewed_by_agencies.find((viewed) => viewed.agency_id.toString() === this.selectedAgencyId);
     },
     interested() {
       if (!this.selectedGrant) {
         return false;
       }
-      return this.selectedGrant.interested_agencies.find((interested) => interested.agency_id === this.agency.id);
+      return this.selectedGrant.interested_agencies.find((interested) => interested.agency_id.toString() === this.selectedAgencyId);
     },
   },
   watch: {
@@ -209,13 +210,13 @@ export default {
       this.debouncedSearchInput = newVal;
     }, 500),
     async markGrantAsViewed() {
-      await this.markGrantAsViewedAction({ grantId: this.selectedGrant.grant_id, agencyId: this.agency.id });
+      await this.markGrantAsViewedAction({ grantId: this.selectedGrant.grant_id, agencyId: this.selectedAgencyId });
     },
     async markGrantAsInterested() {
       if (this.selectedInterestedCode !== null) {
         await this.markGrantAsInterestedAction({
           grantId: this.selectedGrant.grant_id,
-          agencyId: this.agency.id,
+          agencyId: this.selectedAgencyId,
           interestedCode: this.selectedInterestedCode,
         });
       }

--- a/packages/client/src/components/Modals/ProfileSettings.vue
+++ b/packages/client/src/components/Modals/ProfileSettings.vue
@@ -1,0 +1,85 @@
+<template>
+  <div>
+    <b-modal
+      id="profile-settings-modal"
+      ref="modal"
+      title="Profile Settings"
+      @show="resetModal"
+      @hidden="resetModal"
+      ok-only
+    >
+      <h6>Change Agency: </h6>
+      <b-form>
+        <v-select :options="agencies" label="name" :value="formData.selectedAgency" @input="onAgencyChangeSubmit">
+          <template #search="{attributes, events}">
+            <input
+              class="vs__search"
+              :required="!formData.selectedAgency"
+              v-bind="attributes"
+              v-on="events"
+            />
+          </template>
+        </v-select>
+      </b-form>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex';
+// import { required, numeric, minValue } from 'vuelidate/lib/validators';
+
+export default {
+  props: {
+    showModal: Boolean,
+  },
+  data() {
+    return {
+      formData: {
+        selectedAgency: null,
+      },
+    };
+  },
+  validations: {
+    formData: {
+    },
+  },
+  watch: {
+    showModal() {
+      this.$bvModal.show('profile-settings-modal');
+    },
+    // loggedInUser() {
+    //   if(this.loggedInUser) {
+
+    //   }
+    // }
+  },
+  computed: {
+    ...mapGetters({
+      loggedInUser: 'users/loggedInUser',
+      settingsSelectedAgency: 'users/selectedAgency',
+    }),
+    agencies() {
+      if (!this.loggedInUser) {
+        return [];
+      }
+      return this.loggedInUser.agency.subagencies;
+    },
+  },
+  mounted() {
+    this.formData.selectedAgency = this.agencies.find((a) => a.id.toString() === this.settingsSelectedAgency.toString());
+  },
+  methods: {
+    ...mapActions({
+      changeSelectedAgency: 'users/changeSelectedAgency',
+    }),
+    resetModal() {
+      this.$emit('update:showModal', false);
+    },
+    onAgencyChangeSubmit(agency) {
+      this.changeSelectedAgency(agency.id);
+      this.formData.selectedAgency = agency;
+    },
+  },
+};
+</script>

--- a/packages/client/src/components/Modals/ProfileSettings.vue
+++ b/packages/client/src/components/Modals/ProfileSettings.vue
@@ -48,11 +48,6 @@ export default {
     showModal() {
       this.$bvModal.show('profile-settings-modal');
     },
-    // loggedInUser() {
-    //   if(this.loggedInUser) {
-
-    //   }
-    // }
   },
   computed: {
     ...mapGetters({

--- a/packages/client/src/components/Modals/ProfileSettings.vue
+++ b/packages/client/src/components/Modals/ProfileSettings.vue
@@ -48,6 +48,9 @@ export default {
     showModal() {
       this.$bvModal.show('profile-settings-modal');
     },
+    settingsSelectedAgency() {
+      this.formData.selectedAgency = this.settingsSelectedAgency;
+    },
   },
   computed: {
     ...mapGetters({
@@ -62,7 +65,7 @@ export default {
     },
   },
   mounted() {
-    this.formData.selectedAgency = this.agencies.find((a) => a.id.toString() === this.settingsSelectedAgency.toString());
+    this.formData.selectedAgency = this.settingsSelectedAgency;
   },
   methods: {
     ...mapActions({

--- a/packages/client/src/helpers/fetchApi.js
+++ b/packages/client/src/helpers/fetchApi.js
@@ -2,7 +2,7 @@ import store from '@/store';
 
 function getDefaultHeaders() {
   const headers = new Headers();
-  headers.append('agency-id', store.getters['users/selectedAgency']);
+  headers.append('agency-id', store.getters['users/selectedAgencyId']);
   headers.append('Content-Type', 'application/json');
   return headers;
 }

--- a/packages/client/src/helpers/fetchApi.js
+++ b/packages/client/src/helpers/fetchApi.js
@@ -2,9 +2,12 @@ import store from '@/store';
 
 function getDefaultHeaders() {
   const headers = new Headers();
-  headers.append('agency-id', store.getters['users/selectedAgencyId']);
   headers.append('Content-Type', 'application/json');
   return headers;
+}
+
+function addOrganizationId(url) {
+  return `${process.env.VUE_APP_GRANTS_API_URL}${url.replace(':organizationId', store.getters['users/selectedAgencyId'])}`;
 }
 
 export function get(url) {
@@ -12,7 +15,7 @@ export function get(url) {
     credentials: 'include',
     headers: getDefaultHeaders(),
   };
-  return fetch(`${process.env.VUE_APP_GRANTS_API_URL}${url}`, options).then((r) => {
+  return fetch(addOrganizationId(url), options).then((r) => {
     if (r.ok) {
       return r.json();
     }
@@ -29,7 +32,7 @@ export function deleteRequest(url, body) {
     headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
-  return fetch(`${process.env.VUE_APP_GRANTS_API_URL}${url}`, options).then((r) => {
+  return fetch(addOrganizationId(url), options).then((r) => {
     if (r.ok) {
       return r.json();
     }
@@ -46,7 +49,7 @@ export function post(url, body) {
     headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
-  return fetch(`${process.env.VUE_APP_GRANTS_API_URL}${url}`, options).then((r) => {
+  return fetch(addOrganizationId(url), options).then((r) => {
     if (r.ok) {
       return r.json();
     }
@@ -63,7 +66,7 @@ export function put(url, body) {
     headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
-  return fetch(`${process.env.VUE_APP_GRANTS_API_URL}${url}`, options).then((r) => {
+  return fetch(addOrganizationId(url), options).then((r) => {
     if (r.ok) {
       return r.json();
     }

--- a/packages/client/src/helpers/fetchApi.js
+++ b/packages/client/src/helpers/fetchApi.js
@@ -1,6 +1,16 @@
+import store from '@/store';
+
+function getDefaultHeaders() {
+  const headers = new Headers();
+  headers.append('agency-id', store.getters['users/selectedAgency']);
+  headers.append('Content-Type', 'application/json');
+  return headers;
+}
+
 export function get(url) {
   const options = {
     credentials: 'include',
+    headers: getDefaultHeaders(),
   };
   return fetch(`${process.env.VUE_APP_GRANTS_API_URL}${url}`, options).then((r) => {
     if (r.ok) {
@@ -16,9 +26,7 @@ export function deleteRequest(url, body) {
   const options = {
     method: 'DELETE',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
   return fetch(`${process.env.VUE_APP_GRANTS_API_URL}${url}`, options).then((r) => {
@@ -35,9 +43,7 @@ export function post(url, body) {
   const options = {
     method: 'POST',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
   return fetch(`${process.env.VUE_APP_GRANTS_API_URL}${url}`, options).then((r) => {
@@ -54,9 +60,7 @@ export function put(url, body) {
   const options = {
     method: 'PUT',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: getDefaultHeaders(),
     body: JSON.stringify(body),
   };
   return fetch(`${process.env.VUE_APP_GRANTS_API_URL}${url}`, options).then((r) => {

--- a/packages/client/src/main.js
+++ b/packages/client/src/main.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
+import vSelect from 'vue-select';
 import Vuelidate from 'vuelidate';
 
 import App from './App.vue';
@@ -13,6 +14,7 @@ Vue.use(BootstrapVue);
 // Optionally install the BootstrapVue icon components plugin
 Vue.use(IconsPlugin);
 Vue.use(Vuelidate);
+Vue.component('v-select', vSelect);
 
 Vue.config.productionTip = false;
 

--- a/packages/client/src/store/modules/agencies.js
+++ b/packages/client/src/store/modules/agencies.js
@@ -14,10 +14,10 @@ export default {
   },
   actions: {
     fetchAgencies({ commit }) {
-      fetchApi.get('/api/agencies').then((data) => commit('SET_AGENCIES', data));
+      fetchApi.get('/api/organizations/:organizationId/agencies').then((data) => commit('SET_AGENCIES', data));
     },
     async updateThresholds({ dispatch }, { agencyId, warningThreshold, dangerThreshold }) {
-      await fetchApi.put(`/api/agencies/${agencyId}`, {
+      await fetchApi.put(`/api/organizations/:organizationId/agencies/${agencyId}`, {
         // Currently, agencies are seeded into db; only thresholds are mutable.
         warningThreshold,
         dangerThreshold,

--- a/packages/client/src/store/modules/dashboard.js
+++ b/packages/client/src/store/modules/dashboard.js
@@ -34,7 +34,7 @@ export default {
     async fetchDashboard({ commit }) {
       const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
       const timestampQueryString = twentyFourHoursAgo.toISOString();
-      const result = await fetchApi.get(`/api/dashboard?totalGrants=true&totalViewedGrants=true&totalInterestedGrants=true&grantsCreatedFromTs=${timestampQueryString}&grantsUpdatedFromTs=${timestampQueryString}&totalInterestedGrantsByAgencies=true`);
+      const result = await fetchApi.get(`/api/organizations/:organizationId/dashboard?totalGrants=true&totalViewedGrants=true&totalInterestedGrants=true&grantsCreatedFromTs=${timestampQueryString}&grantsUpdatedFromTs=${timestampQueryString}&totalInterestedGrantsByAgencies=true`);
       if (result.totalGrants) {
         commit('SET_TOTAL_GRANTS', result.totalGrants);
       }

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -34,27 +34,27 @@ export default {
         .filter(([key, value]) => value || typeof value === 'number')
         .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
         .join('&');
-      return fetchApi.get(`/api/grants?${query}`)
+      return fetchApi.get(`/api/organizations/:organizationId/grants?${query}`)
         .then((data) => commit('SET_GRANTS', data));
     },
     markGrantAsViewed(context, { grantId, agencyId }) {
-      return fetchApi.put(`/api/grants/${grantId}/view/${agencyId}`);
+      return fetchApi.put(`/api/organizations/:organizationId/grants/${grantId}/view/${agencyId}`);
     },
     getGrantAssignedAgencies(context, { grantId }) {
-      return fetchApi.get(`/api/grants/${grantId}/assign/agencies`);
+      return fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/assign/agencies`);
     },
     assignAgenciesToGrant(context, { grantId, agencyIds }) {
-      return fetchApi.put(`/api/grants/${grantId}/assign/agencies`, {
+      return fetchApi.put(`/api/organizations/:organizationId/grants/${grantId}/assign/agencies`, {
         agencyIds,
       });
     },
     unassignAgenciesToGrant(context, { grantId, agencyIds }) {
-      return fetchApi.deleteRequest(`/api/grants/${grantId}/assign/agencies`, {
+      return fetchApi.deleteRequest(`/api/organizations/:organizationId/grants/${grantId}/assign/agencies`, {
         agencyIds,
       });
     },
     async generateGrantForm(context, { grantId }) {
-      const response = await fetchApi.get(`/api/grants/${grantId}/form/nevada_spoc`);
+      const response = await fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/form/nevada_spoc`);
       const link = document.createElement('a');
       link.href = response.filePath;
       link.setAttribute('download', response.filePath);
@@ -63,35 +63,35 @@ export default {
       link.click();
     },
     fetchInterestedAgencies(context, { grantId }) {
-      return fetchApi.get(`/api/grants/${grantId}/interested`);
+      return fetchApi.get(`/api/organizations/:organizationId/grants/${grantId}/interested`);
     },
     async markGrantAsInterested({ commit }, { grantId, agencyId, interestedCode }) {
-      const interestedAgencies = await fetchApi.put(`/api/grants/${grantId}/interested/${agencyId}`, {
+      const interestedAgencies = await fetchApi.put(`/api/organizations/:organizationId/grants/${grantId}/interested/${agencyId}`, {
         interestedCode,
       });
       commit('UPDATE_GRANT', { grantId, data: { interested_agencies: interestedAgencies } });
     },
     fetchEligibilityCodes({ commit }) {
-      fetchApi.get('/api/eligibility-codes')
+      fetchApi.get('/api/organizations/:organizationId/eligibility-codes')
         .then((data) => commit('SET_ELIGIBILITY_CODES', data));
     },
     fetchInterestedCodes({ commit }) {
-      fetchApi.get('/api/interested-codes')
+      fetchApi.get('/api/organizations/:organizationId/interested-codes')
         .then((data) => commit('SET_INTERESTED_CODES', data));
     },
     async setEligibilityCodeEnabled(context, { code, enabled }) {
-      await fetchApi.put(`/api/eligibility-codes/${code}/enable/${enabled}`);
+      await fetchApi.put(`/api/organizations/:organizationId/eligibility-codes/${code}/enable/${enabled}`);
     },
     fetchKeywords({ commit }) {
-      fetchApi.get('/api/keywords')
+      fetchApi.get('/api/organizations/:organizationId/keywords')
         .then((data) => commit('SET_KEYWORDS', data));
     },
     async createKeyword({ dispatch }, keyword) {
-      await fetchApi.post('/api/keywords', keyword);
+      await fetchApi.post('/api/organizations/:organizationId/keywords', keyword);
       dispatch('fetchKeywords');
     },
     async deleteKeyword({ dispatch }, keywordId) {
-      await fetchApi.deleteRequest(`/api/keywords/${keywordId}`);
+      await fetchApi.deleteRequest(`/api/organizations/:organizationId/keywords/${keywordId}`);
       dispatch('fetchKeywords');
     },
   },

--- a/packages/client/src/store/modules/grants.js
+++ b/packages/client/src/store/modules/grants.js
@@ -29,8 +29,9 @@ export default {
       const query = Object.entries({
         currentPage, perPage, orderBy, searchTerm, interestedByMe, assignedToAgency, aging,
       })
+        // filter out undefined and nulls since api expects parameters not present as undefined
         // eslint-disable-next-line no-unused-vars
-        .filter(([key, value]) => value)
+        .filter(([key, value]) => value || typeof value === 'number')
         .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
         .join('&');
       return fetchApi.get(`/api/grants?${query}`)

--- a/packages/client/src/store/modules/roles.js
+++ b/packages/client/src/store/modules/roles.js
@@ -14,7 +14,7 @@ export default {
   },
   actions: {
     fetchRoles({ commit }) {
-      fetchApi.get('/api/roles').then((data) => commit('SET_ROLES', data));
+      fetchApi.get('/api/organizations/:organizationId/roles').then((data) => commit('SET_ROLES', data));
     },
   },
   mutations: {

--- a/packages/client/src/store/modules/users.js
+++ b/packages/client/src/store/modules/users.js
@@ -46,7 +46,7 @@ export default {
     async logout({ commit }) {
       await fetchApi.get('/api/sessions/logout');
       commit('SET_LOGGED_IN_USER', null);
-      localStorage.setItem('selectedAgency', null);
+      localStorage.removeItem('selectedAgencyId');
     },
     async changeSelectedAgency({ commit }, agencyId) {
       commit('SET_SELECTED_AGENCY', agencyId);

--- a/packages/client/src/store/modules/users.js
+++ b/packages/client/src/store/modules/users.js
@@ -3,6 +3,9 @@ const fetchApi = require('@/helpers/fetchApi');
 function initialState() {
   return {
     loggedInUser: null,
+    settings: {
+      selectedAgency: null,
+    },
     users: [],
   };
 }
@@ -15,15 +18,21 @@ export default {
     users: (state) => state.users,
     userRole: (state, getters) => (getters.loggedInUser ? getters.loggedInUser.role.name : null),
     agency: (state, getters) => (getters.loggedInUser ? getters.loggedInUser.agency : null),
+    selectedAgency: (state) => state.settings.selectedAgency || localStorage.getItem('selectedAgency'),
   },
   actions: {
-    login({ commit }, user) {
+    login({ dispatch, commit, getters }, user) {
+      dispatch('changeSelectedAgency', getters.selectedAgency);
       commit('SET_LOGGED_IN_USER', user);
     },
-    logout({ commit }) {
-      return fetchApi.get('/api/sessions/logout')
-        .then(() => commit('SET_LOGGED_IN_USER', null))
-        .catch(() => commit('SET_LOGGED_IN_USER', null));
+    async logout({ commit }) {
+      await fetchApi.get('/api/sessions/logout');
+      commit('SET_LOGGED_IN_USER', null);
+      localStorage.setItem('selectedAgency', null);
+    },
+    async changeSelectedAgency({ commit }, agencyId) {
+      commit('SET_SELECTED_AGENCY', agencyId);
+      localStorage.setItem('selectedAgency', agencyId);
     },
     fetchUsers({ commit }) {
       return fetchApi.get('/api/users')
@@ -44,6 +53,9 @@ export default {
     },
     SET_USERS(state, users) {
       state.users = users;
+    },
+    SET_SELECTED_AGENCY(state, agencyId) {
+      state.settings.selectedAgency = agencyId;
     },
   },
 };

--- a/packages/client/src/store/modules/users.js
+++ b/packages/client/src/store/modules/users.js
@@ -44,7 +44,7 @@ export default {
       commit('SET_LOGGED_IN_USER', user);
     },
     async logout({ commit }) {
-      await fetchApi.get('/api/sessions/logout');
+      await fetchApi.get('/api/organizations/:organizationId/sessions/logout');
       commit('SET_LOGGED_IN_USER', null);
       localStorage.removeItem('selectedAgencyId');
     },
@@ -53,15 +53,15 @@ export default {
       localStorage.setItem('selectedAgencyId', agencyId);
     },
     fetchUsers({ commit }) {
-      return fetchApi.get('/api/users')
+      return fetchApi.get('/api/organizations/:organizationId/users')
         .then((data) => commit('SET_USERS', data));
     },
     async createUser({ dispatch }, user) {
-      await fetchApi.post('/api/users', user);
+      await fetchApi.post('/api/organizations/:organizationId/users', user);
       await dispatch('fetchUsers');
     },
     async deleteUser({ dispatch }, userId) {
-      await fetchApi.deleteRequest(`/api/users/${userId}`);
+      await fetchApi.deleteRequest(`/api/organizations/:organizationId/users/${userId}`);
       await dispatch('fetchUsers');
     },
   },

--- a/packages/client/src/views/Agencies.vue
+++ b/packages/client/src/views/Agencies.vue
@@ -61,12 +61,13 @@ export default {
     };
   },
   mounted() {
-    this.fetchAgencies();
+    this.setup();
   },
   computed: {
     ...mapGetters({
       agencies: 'agencies/agencies',
       userRole: 'users/userRole',
+      selectedAgency: 'users/selectedAgency',
     }),
     formattedAgencies() {
       return this.agencies.map((agency) => ({
@@ -74,10 +75,18 @@ export default {
       }));
     },
   },
+  watch: {
+    selectedAgency() {
+      this.setup();
+    },
+  },
   methods: {
     ...mapActions({
       fetchAgencies: 'agencies/fetchAgencies',
     }),
+    setup() {
+      this.fetchAgencies();
+    },
     openEditAgencyModal(agency) {
       this.editingAgency = agency;
       this.showEditAgencyModal = true;

--- a/packages/client/src/views/Dashboard.vue
+++ b/packages/client/src/views/Dashboard.vue
@@ -70,7 +70,7 @@ export default {
   },
   mixins: [resizableTableMixin],
   mounted() {
-    this.fetchDashboard();
+    this.setup();
   },
   computed: {
     ...mapGetters({
@@ -83,12 +83,21 @@ export default {
       grantsUpdatedInTimeframe: 'dashboard/grantsUpdatedInTimeframe',
       grantsUpdatedInTimeframeMatchingCriteria: 'dashboard/grantsUpdatedInTimeframeMatchingCriteria',
       totalInterestedGrantsByAgencies: 'dashboard/totalInterestedGrantsByAgencies',
+      selectedAgency: 'users/selectedAgency',
     }),
+  },
+  watch: {
+    selectedAgency() {
+      this.setup();
+    },
   },
   methods: {
     ...mapActions({
       fetchDashboard: 'dashboard/fetchDashboard',
     }),
+    setup() {
+      this.fetchDashboard();
+    },
   },
 };
 </script>

--- a/packages/client/src/views/EligibilityCodes.vue
+++ b/packages/client/src/views/EligibilityCodes.vue
@@ -6,7 +6,7 @@
         <b-form-checkbox
           :checked="data.item.enabled"
           :disabled="userRole === 'staff'"
-          @input="updateEnabled(data.item.code, $event)"/>
+          @change="updateEnabled(data.item.code, $event)"/>
     </template>
   </b-table>
 </section>

--- a/packages/client/src/views/EligibilityCodes.vue
+++ b/packages/client/src/views/EligibilityCodes.vue
@@ -44,19 +44,28 @@ export default {
     };
   },
   mounted() {
-    this.fetchEligibilityCodes();
+    this.setup();
   },
   computed: {
     ...mapGetters({
       eligibilityCodes: 'grants/eligibilityCodes',
       userRole: 'users/userRole',
+      selectedAgency: 'users/selectedAgency',
     }),
+  },
+  watch: {
+    selectedAgency() {
+      this.setup();
+    },
   },
   methods: {
     ...mapActions({
       fetchEligibilityCodes: 'grants/fetchEligibilityCodes',
       setEligibilityCodeEnabled: 'grants/setEligibilityCodeEnabled',
     }),
+    setup() {
+      this.fetchEligibilityCodes();
+    },
     updateEnabled(code, enabled) {
       this.setEligibilityCodeEnabled({ code, enabled });
     },

--- a/packages/client/src/views/Keywords.vue
+++ b/packages/client/src/views/Keywords.vue
@@ -51,19 +51,28 @@ export default {
     };
   },
   mounted() {
-    this.fetchKeywords();
+    this.setup();
   },
   computed: {
     ...mapGetters({
       keywords: 'grants/keywords',
       userRole: 'users/userRole',
+      selectedAgency: 'users/selectedAgency',
     }),
+  },
+  watch: {
+    selectedAgency() {
+      this.setup();
+    },
   },
   methods: {
     ...mapActions({
       fetchKeywords: 'grants/fetchKeywords',
       deleteKeyword: 'grants/deleteKeyword',
     }),
+    setup() {
+      this.fetchKeywords();
+    },
     openAddKeywordModal() {
       this.showAddKeywordModal = true;
     },

--- a/packages/client/src/views/MyGrants.vue
+++ b/packages/client/src/views/MyGrants.vue
@@ -6,9 +6,6 @@
     <b-tab title="Assigned">
       <GrantsTable :showAssignedToAgency="loggedInUser.agency.id"/>
     </b-tab>
-    <b-tab title="Aging">
-      <GrantsTable :showAging="true"/>
-    </b-tab>
   </b-tabs>
 </template>
 

--- a/packages/client/src/views/MyGrants.vue
+++ b/packages/client/src/views/MyGrants.vue
@@ -4,7 +4,7 @@
       <GrantsTable :showInterested="true"/>
     </b-tab>
     <b-tab title="Assigned">
-      <GrantsTable :showAssignedToAgency="loggedInUser.agency.id"/>
+      <GrantsTable :showAssignedToAgency="selectedAgencyId"/>
     </b-tab>
   </b-tabs>
 </template>
@@ -23,7 +23,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      loggedInUser: 'users/loggedInUser',
+      selectedAgencyId: 'users/selectedAgencyId',
     }),
   },
   methods: {},

--- a/packages/client/src/views/Users.vue
+++ b/packages/client/src/views/Users.vue
@@ -66,6 +66,7 @@ export default {
   computed: {
     ...mapGetters({
       users: 'users/users',
+      selectedAgency: 'users/selectedAgency',
     }),
     formattedUsers() {
       return this.users.map((user) => ({
@@ -76,11 +77,19 @@ export default {
       }));
     },
   },
+  watch: {
+    selectedAgency() {
+      this.setup();
+    },
+  },
   methods: {
     ...mapActions({
       fetchUsers: 'users/fetchUsers',
       deleteUser: 'users/deleteUser',
     }),
+    setup() {
+      this.fetchUsers();
+    },
     openAddUserModal() {
       this.showAddUserModal = true;
     },

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,5 +1,9 @@
 POSTGRES_URL="postgresql://localhost:5432/cares_grant"
 
+# integration tests will use this postgres url
+POSTGRES_TEST_URL="postgresql://localhost:5432/cares_grant_test"
+
+
 COOKIE_SECRET=itsasecretsecretsecret
 
 API_DOMAIN=http://localhost:3000

--- a/packages/server/__tests__/api/agencies.test.js
+++ b/packages/server/__tests__/api/agencies.test.js
@@ -1,17 +1,9 @@
 const { expect } = require('chai');
-const fetch = require('node-fetch');
-const { getSessionCookie } = require('./utils');
 require('dotenv').config();
 
+const { getSessionCookie, fetchApi } = require('./utils');
+
 describe('`/api/organizations/:organizationId/agencies` endpoint', async () => {
-    function getEndpoint({ agencyId, url }) {
-        return `${process.env.API_DOMAIN}/api/organizations/${agencyId}${url}`;
-    }
-
-    function fetchApi(url, agencyId, fetchOptions) {
-        return fetch(getEndpoint({ agencyId, url }), fetchOptions);
-    }
-
     const agencies = {
         admin: {
             own: 0,

--- a/packages/server/__tests__/api/agencies.test.js
+++ b/packages/server/__tests__/api/agencies.test.js
@@ -40,7 +40,7 @@ describe('`/api/agencies` endpoint', async () => {
         fetchOptions.staff.headers.cookie = await getSessionCookie('user2@nv.gov');
     });
 
-    context('GET /agencies (list an agency and its subagencies)', async () => {
+    context('GET /agencies?agency=N (list an agency and its subagencies)', async () => {
         context('by a user with admin role', async () => {
             it('lists this user\'s own agency and its subagencies', async () => {
                 // Will default to user's own agency ID

--- a/packages/server/__tests__/api/agencies.test.js
+++ b/packages/server/__tests__/api/agencies.test.js
@@ -3,8 +3,14 @@ const fetch = require('node-fetch');
 const { getSessionCookie } = require('./utils');
 require('dotenv').config();
 
-describe('`/api/agencies` endpoint', async () => {
-    const endpoint = `${process.env.API_DOMAIN}/api/agencies`;
+describe('`/api/organizations/:organizationId/agencies` endpoint', async () => {
+    function getEndpoint({ agencyId, url }) {
+        return `${process.env.API_DOMAIN}/api/organizations/${agencyId}${url}`;
+    }
+
+    function fetchApi(url, agencyId, fetchOptions) {
+        return fetch(getEndpoint({ agencyId, url }), fetchOptions);
+    }
 
     const agencies = {
         admin: {
@@ -40,74 +46,73 @@ describe('`/api/agencies` endpoint', async () => {
         fetchOptions.staff.headers.cookie = await getSessionCookie('user2@nv.gov');
     });
 
-    context('GET /agencies?agency=N (list an agency and its subagencies)', async () => {
+    context('GET organizations/:organizationId/agencies (list an agency and its subagencies)', async () => {
         context('by a user with admin role', async () => {
             it('lists this user\'s own agency and its subagencies', async () => {
                 // Will default to user's own agency ID
-                const response = await fetch(`${endpoint}`, fetchOptions.admin);
+                const response = await fetchApi('/agencies', agencies.admin.own, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(329);
             });
             it('lists a subagency of this user\'s own agency and that subagency\'s subagencies', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.admin.ownSub}`, fetchOptions.admin);
+                const response = await fetchApi('/agencies', agencies.admin.ownSub, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(8);
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.admin.offLimits}`, fetchOptions.admin);
+                const response = await fetchApi('/agencies', agencies.admin.offLimits, fetchOptions.admin);
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
         context('by a user with staff role', async () => {
             it('lists this user\'s own agency', async () => {
                 // Will default to user's own agency ID
-                console.log(`url: ${endpoint}`);
-                const response = await fetch(`${endpoint}`, fetchOptions.staff);
+                const response = await fetchApi('/agencies', agencies.staff.own, fetchOptions.staff);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(1);
                 expect(json[0].id).to.equal(agencies.staff.own);
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.staff.ownSub}`, fetchOptions.staff);
+                const response = await fetchApi('/agencies', agencies.staff.ownSub, fetchOptions.staff);
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.staff.offLimits}`, fetchOptions.staff);
+                const response = await fetchApi('/agencies', agencies.staff.offLimits, fetchOptions.staff);
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
     });
-    context('PUT /agencies/:id (modify an agency\'s data)', async () => {
+    context('PUT /organizations/:organizationId/agencies/:id (modify an agency\'s data)', async () => {
         const body = JSON.stringify({ warningThreshold: 2, dangerThreshold: 1 });
 
         context('by a user with admin role', async () => {
             it('updates this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/${agencies.admin.own}`, { ...fetchOptions.admin, method: 'put', body });
+                const response = await fetchApi(`/agencies/${agencies.admin.own}`, agencies.admin.own, { ...fetchOptions.admin, method: 'put', body });
                 expect(response.statusText).to.equal('OK');
             });
             it('updates a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/${agencies.admin.ownSub}`, { ...fetchOptions.admin, method: 'put', body });
+                const response = await fetchApi(`/agencies/${agencies.admin.ownSub}`, agencies.admin.ownSub, { ...fetchOptions.admin, method: 'put', body });
                 expect(response.statusText).to.equal('OK');
             });
             it('is forbidden for agencies outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}/${agencies.admin.offLimits}`, { ...fetchOptions.admin, method: 'put', body });
+                const response = await fetchApi(`/agencies/${agencies.admin.offLimits}`, agencies.admin.offLimits, { ...fetchOptions.admin, method: 'put', body });
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
         context('by a user with staff role', async () => {
             it('is forbidden for this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/${agencies.staff.own}`, { ...fetchOptions.staff, method: 'put', body });
+                const response = await fetchApi(`/agencies/${agencies.staff.own}`, agencies.staff.own, { ...fetchOptions.staff, method: 'put', body });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/${agencies.staff.ownSub}`, { ...fetchOptions.staff, method: 'put', body });
+                const response = await fetchApi(`/agencies/${agencies.staff.ownSub}`, agencies.staff.ownSub, { ...fetchOptions.staff, method: 'put', body });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for agencies outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}/${agencies.staff.offLimits}`, { ...fetchOptions.staff, method: 'put', body });
+                const response = await fetchApi(`/agencies/${agencies.staff.offLimits}`, agencies.staff.offLimits, { ...fetchOptions.staff, method: 'put', body });
                 expect(response.statusText).to.equal('Forbidden');
             });
         });

--- a/packages/server/__tests__/api/agencies.test.js
+++ b/packages/server/__tests__/api/agencies.test.js
@@ -40,7 +40,7 @@ describe('`/api/agencies` endpoint', async () => {
         fetchOptions.staff.headers.cookie = await getSessionCookie('user2@nv.gov');
     });
 
-    context('GET /agencies?agency=N (list an agency and its subagencies)', async () => {
+    context('GET /agencies (list an agency and its subagencies)', async () => {
         context('by a user with admin role', async () => {
             it('lists this user\'s own agency and its subagencies', async () => {
                 // Will default to user's own agency ID

--- a/packages/server/__tests__/api/eligibilityCodes.test.js
+++ b/packages/server/__tests__/api/eligibilityCodes.test.js
@@ -1,11 +1,9 @@
 const { expect } = require('chai');
-const fetch = require('node-fetch');
-const { getSessionCookie } = require('./utils');
 require('dotenv').config();
 
-describe('`/api/eligibility-codes` endpoint', async () => {
-    const endpoint = `${process.env.API_DOMAIN}/api/eligibility-codes`;
+const { getSessionCookie, fetchApi } = require('./utils');
 
+describe('`/api/eligibility-codes` endpoint', async () => {
     const UNIQUE_CODES = 17; // all agencies have same number of codes
 
     const agencies = {
@@ -46,36 +44,36 @@ describe('`/api/eligibility-codes` endpoint', async () => {
         context('by a user with admin role', async () => {
             it('lists eligibility codes of this user\'s agency', async () => {
                 // Will default to user's own agency ID
-                const response = await fetch(`${endpoint}`, fetchOptions.admin);
+                const response = await fetchApi('/eligibility-codes', agencies.admin.own, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(UNIQUE_CODES);
             });
             it('lists eligibility codes of a subagency of this user\'s agency', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.admin.ownSub}`, fetchOptions.admin);
+                const response = await fetchApi('/eligibility-codes', agencies.admin.ownSub, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(UNIQUE_CODES);
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.admin.offLimits}`, fetchOptions.admin);
+                const response = await fetchApi('/eligibility-codes', agencies.admin.offLimits, fetchOptions.admin);
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
         context('by a user with staff role', async () => {
             it('lists eligibility codes of this user\'s own agency', async () => {
                 // Will default to user's own agency ID
-                const response = await fetch(`${endpoint}`, fetchOptions.staff);
+                const response = await fetchApi('/eligibility-codes', agencies.staff.own, fetchOptions.staff);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(UNIQUE_CODES);
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.staff.ownSub}`, fetchOptions.staff);
+                const response = await fetchApi('/eligibility-codes', agencies.staff.ownSub, fetchOptions.staff);
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.staff.offLimits}`, fetchOptions.staff);
+                const response = await fetchApi('/eligibility-codes', agencies.staff.offLimits, fetchOptions.staff);
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
@@ -84,30 +82,30 @@ describe('`/api/eligibility-codes` endpoint', async () => {
         context('by a user with admin role', async () => {
             it('updates an eligibility code of this user\'s own agency', async () => {
                 // Will default to user's own agency ID
-                const response = await fetch(`${endpoint}/01/enable/false`, { ...fetchOptions.admin, method: 'put' });
+                const response = await fetchApi('/eligibility-codes/01/enable/false', agencies.admin.own, { ...fetchOptions.admin, method: 'put' });
                 expect(response.statusText).to.equal('OK');
             });
             it('updates an eligibility code of a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/02/enable/false?agency=${agencies.admin.ownSub}`, { ...fetchOptions.admin, method: 'put' });
+                const response = await fetchApi('/eligibility-codes/02/enable/false', agencies.admin.ownSub, { ...fetchOptions.admin, method: 'put' });
                 expect(response.statusText).to.equal('OK');
             });
             it('is forbidden for agencies outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}/04/enable/false?agency=${agencies.admin.offLimits}`, { ...fetchOptions.admin, method: 'put' });
+                const response = await fetchApi('/eligibility-codes/04/enable/false', agencies.admin.offLimits, { ...fetchOptions.admin, method: 'put' });
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
         context('by a user with staff role', async () => {
             it('is forbidden for this user\'s own agency', async () => {
                 // Will default to user's own agency ID
-                const response = await fetch(`${endpoint}/01/enable/false`, { ...fetchOptions.staff, method: 'put' });
+                const response = await fetchApi('/eligibility-codes/01/enable/false', agencies.staff.own, { ...fetchOptions.staff, method: 'put' });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/02/enable/false?agency=${agencies.staff.ownSub}`, { ...fetchOptions.staff, method: 'put' });
+                const response = await fetchApi('/eligibility-codes/02/enable/false', agencies.staff.ownSub, { ...fetchOptions.staff, method: 'put' });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for agencies outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}/04/enable/false?agency=${agencies.staff.offLimits}`, { ...fetchOptions.staff, method: 'put' });
+                const response = await fetchApi('/eligibility-codes/04/enable/false', agencies.staff.offLimits, { ...fetchOptions.staff, method: 'put' });
                 expect(response.statusText).to.equal('Forbidden');
             });
         });

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -370,13 +370,13 @@ describe('`/api/grants` endpoint', async () => {
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('rejects requests with agency in query string', async () => {
+            it('ignores agency querystring if agency is passed in params', async () => {
                 const response = await fetch(`${interestEndpoint}/${agencies.ownSubAlternate}?agency=${agencies.own}`, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ interestedCode: 1 }),
                 });
-                expect(response.statusText).to.equal('Bad Request');
+                expect(response.statusText).to.equal('OK');
             });
             it('forbids requests for any agency outside this user\'s hierarchy', async () => {
                 const response = await fetch(`${interestEndpoint}/${agencies.offLimits}`, {

--- a/packages/server/__tests__/api/grants.test.js
+++ b/packages/server/__tests__/api/grants.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
-const fetch = require('node-fetch');
-const { getSessionCookie } = require('./utils');
 require('dotenv').config();
+
+const { getSessionCookie, fetchApi } = require('./utils');
 
 /*
     In general, these tests ...
@@ -10,8 +10,6 @@ require('dotenv').config();
 */
 
 describe('`/api/grants` endpoint', async () => {
-    const endpoint = `${process.env.API_DOMAIN}/api/grants`;
-
     const agencies = {
         own: 384,
         ownSub: 2,
@@ -42,23 +40,23 @@ describe('`/api/grants` endpoint', async () => {
 
     context('PUT api/grants/:grantId/view/:agencyId', async () => {
         context('by a user with admin role', async () => {
-            const viewEndpoint = `${endpoint}/335255/view`;
+            const viewEndpoint = `335255/view`;
             it('marks the grant viewed for this user\'s own agency', async () => {
-                const response = await fetch(`${viewEndpoint}/${agencies.own}`, {
+                const response = await fetchApi(`/grants/${viewEndpoint}/${agencies.own}`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'put',
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('marks the grant viewed for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${viewEndpoint}/${agencies.ownSub}`, {
+                const response = await fetchApi(`/grants/${viewEndpoint}/${agencies.ownSub}`, agencies.ownSub, {
                     ...fetchOptions.admin,
                     method: 'put',
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('forbids requests for any agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${viewEndpoint}/${agencies.offLimits}`, {
+                const response = await fetchApi(`/grants/${viewEndpoint}/${agencies.offLimits}`, agencies.offLimits, {
                     ...fetchOptions.admin,
                     method: 'put',
                 });
@@ -66,22 +64,22 @@ describe('`/api/grants` endpoint', async () => {
             });
         });
         context('by a user with staff role', async () => {
-            const viewEndpoint = `${endpoint}/333333/view`;
+            const viewEndpoint = `/333333/view`;
             it('marks the grant viewed for this user\'s own agency', async () => {
-                const response = await fetch(`${viewEndpoint}/${agencies.own}`, {
+                const response = await fetchApi(`/grants/${viewEndpoint}/${agencies.own}`, agencies.own, {
                     ...fetchOptions.staff,
                     method: 'put',
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('forbids requests for any agency outside this user\'s hierarchy', async () => {
-                let response = await fetch(`${viewEndpoint}/${agencies.ownSub}`, {
+                let response = await fetchApi(`/grants/${viewEndpoint}/${agencies.ownSub}`, agencies.ownSub, {
                     ...fetchOptions.staff,
                     method: 'put',
                 });
                 expect(response.statusText).to.equal('Forbidden');
 
-                response = await fetch(`${viewEndpoint}/${agencies.offLimits}`, {
+                response = await fetchApi(`/grants/${viewEndpoint}/${agencies.offLimits}`, agencies.offLimits, {
                     ...fetchOptions.staff,
                     method: 'put',
                 });
@@ -90,12 +88,12 @@ describe('`/api/grants` endpoint', async () => {
         });
     });
     context('GET /api/grants/:grantId/assign/agencies', async () => {
-        const assignedEndpoint = `${endpoint}/335255/assign/agencies`;
+        const assignedEndpoint = `335255/assign/agencies`;
         context('by a user with admin role', async () => {
             let response;
             let json;
             before(async () => {
-                response = await fetch(assignedEndpoint, fetchOptions.admin);
+                response = await fetchApi(`/grants/${assignedEndpoint}`, agencies.own, fetchOptions.admin);
                 json = await response.json();
             });
             it('includes this user\'s own agency when it is assigned to the grant', async () => {
@@ -111,14 +109,14 @@ describe('`/api/grants` endpoint', async () => {
                 expect(json.every((r) => r.agency_id !== agencies.offLimits)).to.equal(true);
             });
             it('includes only the queried subagency of this user\'s own agency when the subagency is assigned to the grant', async () => {
-                const queryResponse = await fetch(`${assignedEndpoint}?agency=${agencies.ownSub}`, fetchOptions.admin);
+                const queryResponse = await fetchApi(`/grants/${assignedEndpoint}`, agencies.ownSub, fetchOptions.admin);
                 expect(queryResponse.statusText).to.equal('OK');
                 const queryJson = await queryResponse.json();
                 expect(queryJson.length).to.equal(1);
                 expect(queryJson[0].agency_id).to.equal(agencies.ownSub);
             });
             it('forbids requests for agencies outside this user\'s hierarchy', async () => {
-                const badResponse = await fetch(`${assignedEndpoint}?agency=${agencies.offLimits}`, fetchOptions.admin);
+                const badResponse = await fetchApi(`/grants/${assignedEndpoint}`, agencies.offLimits, fetchOptions.admin);
                 expect(badResponse.statusText).to.equal('Forbidden');
             });
         });
@@ -126,7 +124,7 @@ describe('`/api/grants` endpoint', async () => {
             let response;
             let json;
             before(async () => {
-                response = await fetch(assignedEndpoint, fetchOptions.staff);
+                response = await fetchApi(`/grants/${assignedEndpoint}`, agencies.own, fetchOptions.staff);
                 json = await response.json();
             });
             it('includes this user\'s own agency when it is assigned to the grant', async () => {
@@ -142,16 +140,16 @@ describe('`/api/grants` endpoint', async () => {
                 expect(json.every((r) => r.agency_id !== agencies.offLimits)).to.equal(true);
             });
             it('forbids requests for any agency except this user\'s own agency', async () => {
-                const badResponse = await fetch(`${assignedEndpoint}?agency=${agencies.ownSub}`, fetchOptions.staff);
+                const badResponse = await fetchApi(`/grants/${assignedEndpoint}`, agencies.ownSub, fetchOptions.staff);
                 expect(badResponse.statusText).to.equal('Forbidden');
             });
         });
     });
     context('PUT /api/grants/:grantId/assign/agencies', async () => {
-        const assignEndpoint = `${endpoint}/333816/assign/agencies`;
+        const assignEndpoint = `333816/assign/agencies`;
         context('by a user with admin role', async () => {
             it('assigns this user\'s own agency to a grant', async () => {
-                const response = await fetch(assignEndpoint, {
+                const response = await fetchApi(`/grants/${assignEndpoint}`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ agencyIds: [agencies.own] }),
@@ -159,39 +157,25 @@ describe('`/api/grants` endpoint', async () => {
                 expect(response.statusText).to.equal('OK');
             });
             it('assigns subagencies of this user\'s own agency to a grant', async () => {
-                const response = await fetch(assignEndpoint, {
+                const response = await fetchApi(`/grants/${assignEndpoint}`, agencies.ownSub, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ agencyIds: [agencies.ownSub] }),
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('completes valid assignment requests without regard to agency in query string', async () => {
-                const response = await fetch(`${assignEndpoint}?agency=${agencies.ownSub}`, {
-                    ...fetchOptions.admin,
-                    method: 'put',
-                    body: JSON.stringify({ agencyIds: [agencies.own] }),
-                });
-                expect(response.statusText).to.equal('OK');
-            });
             it('forbids requests for any agency outside this user\'s hierarchy', async () => {
-                let response = await fetch(assignEndpoint, {
+                const response = await fetchApi(`/grants/${assignEndpoint}`, agencies.offLimits, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ agencyIds: [agencies.offLimits] }),
-                });
-                expect(response.statusText).to.equal('Forbidden');
-                response = await fetch(`${assignEndpoint}?agency=${agencies.offLimits}`, {
-                    ...fetchOptions.admin,
-                    method: 'put',
-                    body: JSON.stringify({ agencyIds: [agencies.own] }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
         context('by a user with staff role', async () => {
             it('assigns this user\'s own agency to a grant', async () => {
-                const response = await fetch(assignEndpoint, {
+                const response = await fetchApi(`/grants/${assignEndpoint}`, agencies.own, {
                     ...fetchOptions.staff,
                     method: 'put',
                     body: JSON.stringify({ agencyIds: [agencies.own] }),
@@ -199,32 +183,26 @@ describe('`/api/grants` endpoint', async () => {
                 expect(response.statusText).to.equal('OK');
             });
             it('forbids requests for any agency except this user\'s own agency', async () => {
-                let response = await fetch(assignEndpoint, {
+                let response = await fetchApi(`/grants/${assignEndpoint}`, agencies.ownSub, {
                     ...fetchOptions.staff,
                     method: 'put',
                     body: JSON.stringify({ agencyIds: [agencies.ownSub] }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
-                response = await fetch(assignEndpoint, {
-                    ...fetchOptions.staff,
+                response = await fetchApi(`/grants/${assignEndpoint}`, agencies.offLimits, {
+                    ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ agencyIds: [agencies.offLimits] }),
-                });
-                expect(response.statusText).to.equal('Forbidden');
-                response = await fetch(`${assignEndpoint}?agency=${agencies.offLimits}`, {
-                    ...fetchOptions.staff,
-                    method: 'put',
-                    body: JSON.stringify({ agencyIds: [agencies.own] }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
     });
     context('DELETE /api/grants/:grantId/assign/agencies', async () => {
-        const unassignEndpoint = `${endpoint}/333816/assign/agencies`;
+        const unassignEndpoint = `333816/assign/agencies`;
         context('by a user with admin role', async () => {
             it('unassigns this user\'s own agency from a grant', async () => {
-                const response = await fetch(unassignEndpoint, {
+                const response = await fetchApi(`/grants/${unassignEndpoint}`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'delete',
                     body: JSON.stringify({ agencyIds: [agencies.own] }),
@@ -232,39 +210,25 @@ describe('`/api/grants` endpoint', async () => {
                 expect(response.statusText).to.equal('OK');
             });
             it('unassigns subagencies of this user\'s own agency from a grant', async () => {
-                const response = await fetch(unassignEndpoint, {
+                const response = await fetchApi(`/grants/${unassignEndpoint}`, agencies.ownSub, {
                     ...fetchOptions.admin,
                     method: 'delete',
                     body: JSON.stringify({ agencyIds: [agencies.ownSub] }),
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('completes valid unassignment requests without regard to agency in query string', async () => {
-                const response = await fetch(`${unassignEndpoint}?agency=${agencies.ownSub}`, {
-                    ...fetchOptions.admin,
-                    method: 'delete',
-                    body: JSON.stringify({ agencyIds: [agencies.own] }),
-                });
-                expect(response.statusText).to.equal('OK');
-            });
             it('forbids requests for any agency outside this user\'s hierarchy', async () => {
-                let response = await fetch(unassignEndpoint, {
+                const response = await fetchApi(`/grants/${unassignEndpoint}`, agencies.offLimits, {
                     ...fetchOptions.admin,
                     method: 'delete',
                     body: JSON.stringify({ agencyIds: [agencies.offLimits] }),
-                });
-                expect(response.statusText).to.equal('Forbidden');
-                response = await fetch(`${unassignEndpoint}?agency=${agencies.offLimits}`, {
-                    ...fetchOptions.admin,
-                    method: 'delete',
-                    body: JSON.stringify({ agencyIds: [agencies.own] }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
         context('by a user with staff role', async () => {
             it('unassigns this user\'s own agency to a grant', async () => {
-                const response = await fetch(unassignEndpoint, {
+                const response = await fetchApi(`/grants/${unassignEndpoint}`, agencies.own, {
                     ...fetchOptions.staff,
                     method: 'delete',
                     body: JSON.stringify({ agencyIds: [agencies.own] }),
@@ -272,34 +236,28 @@ describe('`/api/grants` endpoint', async () => {
                 expect(response.statusText).to.equal('OK');
             });
             it('forbids requests for any agency except this user\'s own agency', async () => {
-                let response = await fetch(unassignEndpoint, {
+                let response = await fetchApi(`/grants/${unassignEndpoint}`, agencies.ownSub, {
                     ...fetchOptions.staff,
                     method: 'delete',
                     body: JSON.stringify({ agencyIds: [agencies.ownSub] }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
-                response = await fetch(unassignEndpoint, {
+                response = await fetchApi(`/grants/${unassignEndpoint}`, agencies.offLimits, {
                     ...fetchOptions.staff,
                     method: 'delete',
                     body: JSON.stringify({ agencyIds: [agencies.offLimits] }),
-                });
-                expect(response.statusText).to.equal('Forbidden');
-                response = await fetch(`${unassignEndpoint}?agency=${agencies.offLimits}`, {
-                    ...fetchOptions.staff,
-                    method: 'delete',
-                    body: JSON.stringify({ agencyIds: [agencies.own] }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
     });
     context('GET /api/grants/:grantId/interested', async () => {
-        const interestEndpoint = `${endpoint}/335255/interested`;
+        const interestEndpoint = `335255/interested`;
         context('by a user with admin role', async () => {
             let response;
             let json;
             before(async () => {
-                response = await fetch(interestEndpoint, fetchOptions.admin);
+                response = await fetchApi(`/grants/${interestEndpoint}`, agencies.own, fetchOptions.admin);
                 json = await response.json();
             });
             it('includes this user\'s own agency when it is interested in the grant', async () => {
@@ -315,14 +273,14 @@ describe('`/api/grants` endpoint', async () => {
                 expect(json.every((r) => r.agency_id !== agencies.offLimits)).to.equal(true);
             });
             it('includes only the queried subagency of this user\'s own agency when the subagency is interested in the grant', async () => {
-                const queryResponse = await fetch(`${interestEndpoint}?agency=${agencies.ownSub}`, fetchOptions.admin);
+                const queryResponse = await fetchApi(`/grants/${interestEndpoint}`, agencies.ownSub, fetchOptions.admin);
                 expect(queryResponse.statusText).to.equal('OK');
                 const queryJson = await queryResponse.json();
                 expect(queryJson.length).to.equal(1);
                 expect(queryJson[0].agency_id).to.equal(agencies.ownSub);
             });
             it('forbids requests for agencies outside this user\'s hierarchy', async () => {
-                const badResponse = await fetch(`${interestEndpoint}?agency=${agencies.offLimits}`, fetchOptions.admin);
+                const badResponse = await fetchApi(`/grants/${interestEndpoint}`, agencies.offLimits, fetchOptions.admin);
                 expect(badResponse.statusText).to.equal('Forbidden');
             });
         });
@@ -330,7 +288,7 @@ describe('`/api/grants` endpoint', async () => {
             let response;
             let json;
             before(async () => {
-                response = await fetch(interestEndpoint, fetchOptions.staff);
+                response = await fetchApi(`/grants/${interestEndpoint}`, agencies.own, fetchOptions.staff);
                 json = await response.json();
             });
             it('includes this user\'s own agency when it is interested in the grant', async () => {
@@ -346,16 +304,16 @@ describe('`/api/grants` endpoint', async () => {
                 expect(json.every((r) => r.agency_id !== agencies.offLimits)).to.equal(true);
             });
             it('forbids requests for any agency except this user\'s own agency', async () => {
-                const badResponse = await fetch(`${interestEndpoint}?agency=${agencies.ownSub}`, fetchOptions.staff);
+                const badResponse = await fetchApi(`/grants/${interestEndpoint}`, agencies.ownSub, fetchOptions.staff);
                 expect(badResponse.statusText).to.equal('Forbidden');
             });
         });
     });
     context('PUT /api/grants/:grantId/interested/:agencyId', async () => {
         context('by a user with admin role', async () => {
-            const interestEndpoint = `${endpoint}/0/interested`;
+            const interestEndpoint = `0/interested`;
             it('records this user\'s own agency\'s interest in a grant', async () => {
-                const response = await fetch(`${interestEndpoint}/${agencies.own}`, {
+                const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.own}`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ interestedCode: 1 }),
@@ -363,15 +321,7 @@ describe('`/api/grants` endpoint', async () => {
                 expect(response.statusText).to.equal('OK');
             });
             it('records this user\'s own agency\'s subagencies\' interest in a grant', async () => {
-                const response = await fetch(`${interestEndpoint}/${agencies.ownSub}`, {
-                    ...fetchOptions.admin,
-                    method: 'put',
-                    body: JSON.stringify({ interestedCode: 1 }),
-                });
-                expect(response.statusText).to.equal('OK');
-            });
-            it('ignores agency querystring if agency is passed in params', async () => {
-                const response = await fetch(`${interestEndpoint}/${agencies.ownSubAlternate}?agency=${agencies.own}`, {
+                const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.ownSub}`, agencies.ownSub, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ interestedCode: 1 }),
@@ -379,7 +329,7 @@ describe('`/api/grants` endpoint', async () => {
                 expect(response.statusText).to.equal('OK');
             });
             it('forbids requests for any agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${interestEndpoint}/${agencies.offLimits}`, {
+                const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.offLimits}`, agencies.offLimits, {
                     ...fetchOptions.admin,
                     method: 'put',
                     body: JSON.stringify({ interestedCode: 1 }),
@@ -388,31 +338,23 @@ describe('`/api/grants` endpoint', async () => {
             });
         });
         context('by a user with staff role', async () => {
-            const interestEndpoint = `${endpoint}/333333/interested`;
+            const interestEndpoint = `333333/interested`;
             it('records this user\'s own agency\'s interest in a grant', async () => {
-                const response = await fetch(`${interestEndpoint}/${agencies.own}`, {
+                const response = await fetchApi(`/grants/${interestEndpoint}/${agencies.own}`, agencies.own, {
                     ...fetchOptions.staff,
                     method: 'put',
                     body: JSON.stringify({ interestedCode: 1 }),
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('forbids requests with agency in query string', async () => {
-                const response = await fetch(`${interestEndpoint}/${agencies.ownSubAlternate}?agency=${agencies.own}`, {
-                    ...fetchOptions.staff,
-                    method: 'put',
-                    body: JSON.stringify({ interestedCode: 1 }),
-                });
-                expect(response.statusText).to.equal('Forbidden');
-            });
             it('forbids requests for any agency except this user\'s own agency', async () => {
-                let response = await fetch(`${interestEndpoint}/${agencies.ownSub}`, {
+                let response = await fetchApi(`/grants/${interestEndpoint}/${agencies.ownSub}`, agencies.ownSub, {
                     ...fetchOptions.staff,
                     method: 'put',
                     body: JSON.stringify({ interestedCode: 1 }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
-                response = await fetch(`${interestEndpoint}/${agencies.offLimits}`, {
+                response = await fetchApi(`/grants/${interestEndpoint}/${agencies.offLimits}`, agencies.offLimits, {
                     ...fetchOptions.staff,
                     method: 'put',
                     body: JSON.stringify({ interestedCode: 1 }),

--- a/packages/server/__tests__/api/keywords.test.js
+++ b/packages/server/__tests__/api/keywords.test.js
@@ -1,11 +1,9 @@
 const { expect } = require('chai');
-const fetch = require('node-fetch');
-const { getSessionCookie } = require('./utils');
 require('dotenv').config();
 
-describe('`/api/keywords` endpoint', async () => {
-    const endpoint = `${process.env.API_DOMAIN}/api/keywords`;
+const { getSessionCookie, fetchApi } = require('./utils');
 
+describe('`/api/keywords` endpoint', async () => {
     const UNIQUE_KEYWORDS = 7; // all agencies have the same keywords
 
     const agencies = {
@@ -42,43 +40,43 @@ describe('`/api/keywords` endpoint', async () => {
         fetchOptions.staff.headers.cookie = await getSessionCookie('user1@nv.gov');
     });
 
-    context('GET /keywords?agency=N (list keywords for an agency)', async () => {
+    context('GET api/keywords', async () => {
         context('by a user with admin role', async () => {
             it('lists keywords of this user\'s own agency', async () => {
                 // Will default to user's own agency ID
-                const response = await fetch(`${endpoint}`, fetchOptions.admin);
+                const response = await fetchApi(`/keywords`, agencies.admin.own, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(UNIQUE_KEYWORDS);
                 expect((json.every((r) => r.agency_id === agencies.admin.own))).to.equal(true);
             });
             it('lists keywords of a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.admin.ownSub}`, fetchOptions.admin);
+                const response = await fetchApi(`/keywords`, agencies.admin.ownSub, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(UNIQUE_KEYWORDS);
                 expect((json.every((r) => r.agency_id === agencies.admin.ownSub))).to.equal(true);
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.admin.offLimits}`, fetchOptions.admin);
+                const response = await fetchApi(`/keywords`, agencies.admin.offLimits, fetchOptions.admin);
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
         context('by a user with staff role', async () => {
             it('lists keywords of this user\'s own agency', async () => {
                 // Will default to user's own agency ID
-                const response = await fetch(`${endpoint}`, fetchOptions.staff);
+                const response = await fetchApi(`/keywords`, agencies.staff.own, fetchOptions.staff);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(UNIQUE_KEYWORDS);
                 expect((json.every((r) => r.agency_id === agencies.staff.own))).to.equal(true);
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.staff.ownSub}`, fetchOptions.staff);
+                const response = await fetchApi(`/keywords`, agencies.staff.ownSub, fetchOptions.staff);
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.staff.offLimits}`, fetchOptions.staff);
+                const response = await fetchApi(`/keywords`, agencies.staff.offLimits, fetchOptions.staff);
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
@@ -91,7 +89,7 @@ describe('`/api/keywords` endpoint', async () => {
         };
         context('by a user with admin role', async () => {
             it('creates a keyword for this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}`, {
+                const response = await fetchApi(`/keywords`, agencies.admin.own, {
                     ...fetchOptions.admin,
                     method: 'post',
                     body: JSON.stringify({ ...keyword }),
@@ -101,7 +99,7 @@ describe('`/api/keywords` endpoint', async () => {
                 expect(Number(json.agency_id)).to.equal(agencies.admin.own);
             });
             it('creates a keyword for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.admin.ownSub}`, {
+                const response = await fetchApi(`/keywords`, agencies.admin.ownSub, {
                     ...fetchOptions.admin,
                     method: 'post',
                     body: JSON.stringify({ ...keyword }),
@@ -111,7 +109,7 @@ describe('`/api/keywords` endpoint', async () => {
                 expect(Number(json.agency_id)).to.equal(agencies.admin.ownSub);
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.admin.offLimits}`, {
+                const response = await fetchApi(`/keywords`, agencies.admin.offLimits, {
                     ...fetchOptions.admin,
                     method: 'post',
                     body: JSON.stringify({ ...keyword }),
@@ -121,15 +119,15 @@ describe('`/api/keywords` endpoint', async () => {
         });
         context('by a user with staff role', async () => {
             it('is forbidden for this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}`, {
+                const response = await fetchApi(`/keywords`, agencies.staff.own, {
                     ...fetchOptions.staff,
                     method: 'post',
-                    body: JSON.stringify({ ...keyword, agency: agencies.staff.own }),
+                    body: JSON.stringify({ ...keyword }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.staff.ownSub}`, {
+                const response = await fetchApi(`/keywords`, agencies.staff.ownSub, {
                     ...fetchOptions.staff,
                     method: 'post',
                     body: JSON.stringify({ ...keyword }),
@@ -137,7 +135,7 @@ describe('`/api/keywords` endpoint', async () => {
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.staff.offLimits}`, {
+                const response = await fetchApi(`/keywords`, agencies.staff.offLimits, {
                     ...fetchOptions.staff,
                     method: 'post',
                     body: JSON.stringify({ ...keyword }),
@@ -149,21 +147,21 @@ describe('`/api/keywords` endpoint', async () => {
     context('DELETE /keywords/:id (delete a keyword for an agency)', async () => {
         context('by a user with admin role', async () => {
             it('deletes a keyword of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/16`, {
+                const response = await fetchApi(`/keywords/16`, agencies.admin.own, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('deletes a keyword of a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/143`, {
+                const response = await fetchApi(`/keywords/143`, agencies.admin.ownSub, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('is forbidden for a keyword of an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}/4`, {
+                const response = await fetchApi(`/keywords/4`, agencies.admin.offLimits, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
@@ -172,21 +170,21 @@ describe('`/api/keywords` endpoint', async () => {
         });
         context('by a user with staff role', async () => {
             it('is forbidden for this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/17`, {
+                const response = await fetchApi(`/keywords/17`, agencies.staff.own, {
                     ...fetchOptions.staff,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/144`, {
+                const response = await fetchApi(`/keywords/144`, agencies.staff.ownSub, {
                     ...fetchOptions.staff,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}/4`, {
+                const response = await fetchApi(`/keywords/4`, agencies.staff.offLimits, {
                     ...fetchOptions.staff,
                     method: 'delete',
                 });

--- a/packages/server/__tests__/api/users.test.js
+++ b/packages/server/__tests__/api/users.test.js
@@ -58,7 +58,7 @@ describe('`/api/users` endpoint', async () => {
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('is forbidden for an agency outside this user\'s hierarchy', async () => {
+            it('is forbidden for an agency outside this user\'s hierarchyaa', async () => {
                 const response = await fetch(`${endpoint}`, {
                     ...fetchOptions.admin,
                     method: 'post',
@@ -145,7 +145,7 @@ describe('`/api/users` endpoint', async () => {
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('is forbidden for a user in an agency outside this user\'s hierarchy', async () => {
+            it('is forbidden for a user in an agency outside this user\'s hierarchyaaaa', async () => {
                 const response = await fetch(`${endpoint}/4`, {
                     ...fetchOptions.admin,
                     method: 'delete',

--- a/packages/server/__tests__/api/users.test.js
+++ b/packages/server/__tests__/api/users.test.js
@@ -1,11 +1,9 @@
 const { expect } = require('chai');
-const fetch = require('node-fetch');
-const { getSessionCookie } = require('./utils');
 require('dotenv').config();
 
-describe('`/api/users` endpoint', async () => {
-    const endpoint = `${process.env.API_DOMAIN}/api/users`;
+const { getSessionCookie, fetchApi } = require('./utils');
 
+describe('`/api/users` endpoint', async () => {
     const agencies = {
         own: 384,
         ownSub: 113,
@@ -43,52 +41,52 @@ describe('`/api/users` endpoint', async () => {
 
         context('by a user with admin role', async () => {
             it('creates a user in this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}`, {
+                const response = await fetchApi(`/users`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'post',
-                    body: JSON.stringify({ ...user, email: `1${user.email}`, agency: agencies.own }),
+                    body: JSON.stringify({ ...user, email: `1${user.email}` }),
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('creates a user in a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}`, {
+                const response = await fetchApi(`/users`, agencies.ownSub, {
                     ...fetchOptions.admin,
                     method: 'post',
-                    body: JSON.stringify({ ...user, email: `2${user.email}`, agency: agencies.ownSub }),
+                    body: JSON.stringify({ ...user, email: `2${user.email}` }),
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}`, {
+                const response = await fetchApi(`/users`, agencies.offLimits, {
                     ...fetchOptions.admin,
                     method: 'post',
-                    body: JSON.stringify({ ...user, email: `3${user.email}`, agency: agencies.offLimits }),
+                    body: JSON.stringify({ ...user, email: `3${user.email}` }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
         context('by a user with staff role', async () => {
             it('is forbidden for this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}`, {
+                const response = await fetchApi(`/users`, agencies.own, {
                     ...fetchOptions.staff,
                     method: 'post',
-                    body: JSON.stringify({ ...user, agency: agencies.own }),
+                    body: JSON.stringify({ ...user }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}`, {
+                const response = await fetchApi(`/users`, agencies.ownSub, {
                     ...fetchOptions.staff,
                     method: 'post',
-                    body: JSON.stringify({ ...user, agency: agencies.ownSub }),
+                    body: JSON.stringify({ ...user }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}`, {
+                const response = await fetchApi(`/users`, agencies.offLimits, {
                     ...fetchOptions.staff,
                     method: 'post',
-                    body: JSON.stringify({ ...user, agency: agencies.offLimits }),
+                    body: JSON.stringify({ ...user }),
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
@@ -98,33 +96,33 @@ describe('`/api/users` endpoint', async () => {
     context('GET /api/users?agency=N (list users for an agency)', async () => {
         context('by a user with admin role', async () => {
             it('lists users for this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}`, fetchOptions.admin);
+                const response = await fetchApi(`/users`, agencies.own, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(11);
             });
             it('lists users for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.ownSub}`, fetchOptions.admin);
+                const response = await fetchApi(`/users`, agencies.ownSub, fetchOptions.admin);
                 expect(response.statusText).to.equal('OK');
                 const json = await response.json();
                 expect(json.length).to.equal(6);
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.offLimits}`, fetchOptions.admin);
+                const response = await fetchApi(`/users`, agencies.offLimits, fetchOptions.admin);
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
         context('by a user with staff role', () => {
             it('is forbidden for this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}`, fetchOptions.staff);
+                const response = await fetchApi(`/users`, agencies.own, fetchOptions.staff);
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.ownSub}`, fetchOptions.staff);
+                const response = await fetchApi(`/users`, agencies.ownSub, fetchOptions.staff);
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}?agency=${agencies.offLimits}`, fetchOptions.staff);
+                const response = await fetchApi(`/users`, agencies.offLimits, fetchOptions.staff);
                 expect(response.statusText).to.equal('Forbidden');
             });
         });
@@ -132,21 +130,21 @@ describe('`/api/users` endpoint', async () => {
     context('DELETE /api/users/:id', async () => {
         context('by a user with admin role', async () => {
             it('deletes a user in this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/8`, {
+                const response = await fetchApi(`/users/8`, agencies.own, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('deletes a user in a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/9`, {
+                const response = await fetchApi(`/users/9`, agencies.ownSub, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('OK');
             });
             it('is forbidden for a user in an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}/4`, {
+                const response = await fetchApi(`/users/4`, agencies.offLimits, {
                     ...fetchOptions.admin,
                     method: 'delete',
                 });
@@ -155,21 +153,21 @@ describe('`/api/users` endpoint', async () => {
         });
         context('by a user with staff role', async () => {
             it('is forbidden for this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/8`, {
+                const response = await fetchApi(`/users/8`, agencies.own, {
                     ...fetchOptions.staff,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for a subagency of this user\'s own agency', async () => {
-                const response = await fetch(`${endpoint}/9`, {
+                const response = await fetchApi(`/users/9`, agencies.ownSub, {
                     ...fetchOptions.staff,
                     method: 'delete',
                 });
                 expect(response.statusText).to.equal('Forbidden');
             });
             it('is forbidden for an agency outside this user\'s hierarchy', async () => {
-                const response = await fetch(`${endpoint}/4`, {
+                const response = await fetchApi(`/users/4`, agencies.offLimits, {
                     ...fetchOptions.staff,
                     method: 'delete',
                 });

--- a/packages/server/__tests__/api/users.test.js
+++ b/packages/server/__tests__/api/users.test.js
@@ -58,7 +58,7 @@ describe('`/api/users` endpoint', async () => {
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('is forbidden for an agency outside this user\'s hierarchyaa', async () => {
+            it('is forbidden for an agency outside this user\'s hierarchy', async () => {
                 const response = await fetch(`${endpoint}`, {
                     ...fetchOptions.admin,
                     method: 'post',
@@ -145,7 +145,7 @@ describe('`/api/users` endpoint', async () => {
                 });
                 expect(response.statusText).to.equal('OK');
             });
-            it('is forbidden for a user in an agency outside this user\'s hierarchyaaaa', async () => {
+            it('is forbidden for a user in an agency outside this user\'s hierarchy', async () => {
                 const response = await fetch(`${endpoint}/4`, {
                     ...fetchOptions.admin,
                     method: 'delete',

--- a/packages/server/__tests__/api/utils.js
+++ b/packages/server/__tests__/api/utils.js
@@ -4,7 +4,7 @@ require('dotenv').config();
 
 const knex = require('knex')({
     client: 'pg',
-    connection: process.env.POSTGRES_URL,
+    connection: process.env.POSTGRES_TEST_URL,
 });
 
 async function getSessionCookie(email) {

--- a/packages/server/__tests__/api/utils.js
+++ b/packages/server/__tests__/api/utils.js
@@ -30,6 +30,15 @@ async function getSessionCookie(email) {
     return response.headers.raw()['set-cookie'];
 }
 
+function getEndpoint({ agencyId, url }) {
+    return `${process.env.API_DOMAIN}/api/organizations/${agencyId}${url}`;
+}
+
+function fetchApi(url, agencyId, fetchOptions) {
+    return fetch(getEndpoint({ agencyId, url }), fetchOptions);
+}
+
 module.exports = {
     getSessionCookie,
+    fetchApi,
 };

--- a/packages/server/__tests__/db/db.test.js
+++ b/packages/server/__tests__/db/db.test.js
@@ -71,12 +71,11 @@ describe('db', () => {
         });
     });
 
-    context('getAgencyCriteriaForUserId', () => {
-        it('gets agency criteria associated with a userId', async () => {
+    context('getAgencyCriteriaForAgency', () => {
+        it('gets agency criteria associated with an agency', async () => {
             // eslint-disable-next-line max-len
-            const staffUserId = await knex(TABLES.users).select('id').where('email', fixtures.users.staffUser.email);
-
-            const result = await db.getAgencyCriteriaForUserId(staffUserId[0].id);
+            const staffUserId = await knex(TABLES.users).where('email', fixtures.users.staffUser.email);
+            const result = await db.getAgencyCriteriaForAgency(staffUserId[0].agency_id);
 
             expect(result).to.have.property('eligibilityCodes').with.lengthOf(1);
             expect(result.eligibilityCodes[0])

--- a/packages/server/__tests__/resetdb.js
+++ b/packages/server/__tests__/resetdb.js
@@ -3,6 +3,10 @@ const { exec } = require('child_process');
 
 let { log } = console;
 let { dir } = console;
+dir(__dirname);
+const knexfilePath = path.resolve(__dirname, '../knexfile.js');
+// eslint-disable-next-line import/no-dynamic-require
+const knexfile = require(path.resolve(__dirname, '../knexfile.js'));
 
 function execShellCommand(cmd, options = {}) {
     return new Promise((resolve, reject) => {
@@ -26,10 +30,7 @@ async function resetDB({ verbose = false }) {
         dir = () => { };
     }
 
-    dir(__dirname);
-    const knexfile = path.resolve(__dirname, '../knexfile.js');
-
-    let url = process.env.POSTGRES_URL;
+    let url = knexfile.test.connection;
     const dbName = url.substring(url.lastIndexOf('/') + 1);
     url = url.substring(0, url.lastIndexOf('/'));
 
@@ -50,7 +51,7 @@ async function resetDB({ verbose = false }) {
         await execShellCommand(`psql ${url} -c "CREATE DATABASE ${dbName}"`);
         console.log(`Seeding database ${dbName}`);
         await execShellCommand(`yarn knex migrate:latest`, options);
-        await execShellCommand(`yarn knex --knexfile ${knexfile} seed:run`, options);
+        await execShellCommand(`yarn knex --knexfile ${knexfilePath} seed:run`, options);
     } catch (err) {
         console.dir(err);
         return err;

--- a/packages/server/__tests__/resetdb.js
+++ b/packages/server/__tests__/resetdb.js
@@ -50,7 +50,7 @@ async function resetDB({ verbose = false }) {
         console.log(`Re-creating database ${dbName}`);
         await execShellCommand(`psql ${url} -c "CREATE DATABASE ${dbName}"`);
         console.log(`Seeding database ${dbName}`);
-        await execShellCommand(`yarn knex migrate:latest`, options);
+        await execShellCommand(`yarn knex --knexfile ${knexfilePath} migrate:latest`, options);
         await execShellCommand(`yarn knex --knexfile ${knexfilePath} seed:run`, options);
     } catch (err) {
         console.dir(err);

--- a/packages/server/__tests__/resetdb.js
+++ b/packages/server/__tests__/resetdb.js
@@ -31,14 +31,12 @@ async function resetDB({ verbose = false }) {
     }
 
     let url = knexfile.test.connection;
-    const dbName = url.substring(url.lastIndexOf('/') + 1);
-    url = url.substring(0, url.lastIndexOf('/'));
-
-    if (!process.env.OK_TO_DROP_DB || process.env.OK_TO_DROP_DB !== 'TRUE') {
-        console.log(`For convenience, this process CAN automatically drop, recreate, and seed database '${dbName}'`);
-        console.log('For safety, this process WILL NOT take these steps unless you set environment variable: OK_TO_DROP_DB=TRUE\n');
+    if (!url) {
+        console.log('You must set POSTGRES_TEST_URL as an environment variable');
         process.exit(0);
     }
+    const dbName = url.substring(url.lastIndexOf('/') + 1);
+    url = url.substring(0, url.lastIndexOf('/'));
 
     const options = {
         env: process.env,

--- a/packages/server/knexfile.js
+++ b/packages/server/knexfile.js
@@ -1,6 +1,20 @@
 // Update with your config settings.
 
 module.exports = {
+    test: {
+        client: 'pg',
+        connection: process.env.POSTGRES_TEST_URL,
+        pool: {
+            min: 2,
+            max: 10,
+        },
+        migrations: {
+            tableName: 'migrations',
+        },
+        seeds: {
+            directory: './seeds/dev',
+        },
+    },
     development: {
         client: 'pg',
         connection: process.env.POSTGRES_URL,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,7 @@
     "serve": "nodemon src",
     "test": "mocha __tests__/*.test.js",
     "test:db": "__tests__/db/run-tests.sh",
-    "test:api": "SUPPRESS_EMAIL=TRUE node src > /dev/null & mocha --require __tests__/api/fixtures.js __tests__/api/*.test.js && pkill -fn 'node src'",
+    "test:api": "NODE_ENV=test SUPPRESS_EMAIL=TRUE node src > test.log & NODE_ENV=test mocha --require __tests__/api/fixtures.js __tests__/api/*.test.js && pkill -fn 'node src'",
     "lint": "eslint \"**/*.js\"",
     "pre-commit": "yarn lint"
   },

--- a/packages/server/src/configure.js
+++ b/packages/server/src/configure.js
@@ -26,16 +26,16 @@ module.exports = (app) => {
     app.use(morgan('common'));
     app.use(cookieParser(process.env.COOKIE_SECRET));
     app.use(bodyParser.json());
-    app.use('/api/users', require('./routes/users'));
-    app.use('/api/roles', require('./routes/roles'));
+    app.use('/api/organizations/:organizationId/users', require('./routes/users'));
+    app.use('/api/organizations/:organizationId/roles', require('./routes/roles'));
     app.use('/api/sessions', require('./routes/sessions'));
-    app.use('/api/agencies', require('./routes/agencies'));
-    app.use('/api/grants', require('./routes/grants'));
-    app.use('/api/dashboard', require('./routes/dashboard'));
-    app.use('/api/eligibility-codes', require('./routes/eligibilityCodes'));
-    app.use('/api/interested-codes', require('./routes/interestedCodes'));
-    app.use('/api/keywords', require('./routes/keywords'));
-    app.use('/api/refresh', require('./routes/refresh'));
+    app.use('/api/organizations/:organizationId/agencies', require('./routes/agencies'));
+    app.use('/api/organizations/:organizationId/grants', require('./routes/grants'));
+    app.use('/api/organizations/:organizationId/dashboard', require('./routes/dashboard'));
+    app.use('/api/organizations/:organizationId/eligibility-codes', require('./routes/eligibilityCodes'));
+    app.use('/api/organizations/:organizationId/interested-codes', require('./routes/interestedCodes'));
+    app.use('/api/organizations/:organizationId/keywords', require('./routes/keywords'));
+    app.use('/api/organizations/:organizationId/refresh', require('./routes/refresh'));
 
     const staticMiddleware = express.static(publicPath, {
         etag: true,

--- a/packages/server/src/db/connection.js
+++ b/packages/server/src/db/connection.js
@@ -1,4 +1,4 @@
-const db = process.env.POSTGRES_URL;
+const db = process.env.NODE_ENV !== 'test' ? process.env.POSTGRES_URL : process.env.POSTGRES_TEST_URL;
 
 const knex = require('knex')({
     client: 'pg',

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -122,11 +122,10 @@ async function getUser(id) {
     return user;
 }
 
-async function getAgencyCriteriaForUserId(userId) {
-    const user = await getUser(userId);
-    const eligibilityCodes = await getAgencyEligibilityCodes(user.agency.id);
+async function getAgencyCriteriaForAgency(agencyId) {
+    const eligibilityCodes = await getAgencyEligibilityCodes(agencyId);
     const enabledECodes = eligibilityCodes.filter((e) => e.enabled);
-    const keywords = await getAgencyKeywords(user.agency.id);
+    const keywords = await getAgencyKeywords(agencyId);
 
     return {
         eligibilityCodes: enabledECodes.map((c) => c.code),
@@ -554,7 +553,7 @@ module.exports = {
     createUser,
     deleteUser,
     getUser,
-    getAgencyCriteriaForUserId,
+    getAgencyCriteriaForAgency,
     isSubOrganization,
     getRoles,
     createAccessToken,

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -7,10 +7,14 @@ try {
     // eslint-disable-next-line global-require
     const crypto = require('crypto');
     v4 = crypto.randomUUID;
+    if (!v4) {
+        // node v12 doesnt have randomUUID
+        throw new Error();
+    }
 } catch (err) {
     console.log('Node lacks crypto support!');
     // eslint-disable-next-line global-require
-    v4 = require('uuid').v4;
+    ({ v4 } = require('uuid'));
 }
 
 const knex = require('./connection');
@@ -99,11 +103,6 @@ async function getUser(id) {
         };
     }
     if (user.agency_id != null) {
-        let subagencies = [user.agency_id];
-        if (user.role.name === 'admin') {
-            const result = await getAgencies(user.agency_id);
-            subagencies = result.map((rec) => rec.id);
-        }
         user.agency = {
             id: user.agency_id,
             name: user.agency_name,
@@ -111,8 +110,14 @@ async function getUser(id) {
             agency_parent_id: user.agency_parent_id,
             warning_threshold: user.agency_warning_threshold,
             danger_threshold: user.agency_danger_threshold,
-            subagencies,
         };
+        let subagencies = [];
+        if (user.role.name === 'admin') {
+            subagencies = await getAgencies(user.agency_id);
+        }
+        // push the current agency
+        subagencies.push({ ...user.agency });
+        user.agency.subagencies = subagencies;
     }
     return user;
 }

--- a/packages/server/src/db/index.js
+++ b/packages/server/src/db/index.js
@@ -114,9 +114,9 @@ async function getUser(id) {
         let subagencies = [];
         if (user.role.name === 'admin') {
             subagencies = await getAgencies(user.agency_id);
+        } else {
+            subagencies.push({ ...user.agency });
         }
-        // push the current agency
-        subagencies.push({ ...user.agency });
         user.agency.subagencies = subagencies;
     }
     return user;

--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -34,15 +34,16 @@ async function requireAdminUser(req, res, next) {
     //  a route parameter :agency
     //  a route parameter :agencyId
     //  a body field named 'agency'
-    const headerAgency = Number(req.headers['agency-id']);
-    const queryAgency = Number(req.query.agency);
-    const paramAgency = Number(req.params.agency);
-    const paramAgencyId = Number(req.params.agencyId);
-    const bodyAgency = Number(req.body.agency);
+    const headerAgency = req.headers['agency-id'];
+    const queryAgency = req.query.agency;
+    const paramAgency = req.params.agency;
+    const paramAgencyId = req.params.agencyId;
+    // since the body is JSON, agency field will be a number, to keep everything the same type, convert it to a string
+    const bodyAgency = req.body.agency !== undefined && req.body.agency !== null ? req.body.agency.toString() : null;
 
-    const requestAgency = bodyAgency || paramAgency || paramAgencyId || queryAgency || headerAgency;
+    const requestAgency = Number(bodyAgency || paramAgency || paramAgencyId || queryAgency || headerAgency);
 
-    if (requestAgency !== null || requestAgency !== undefined) {
+    if (!Number.isNaN(requestAgency)) {
         const authorized = await isAuthorized(req.signedCookies.userId, requestAgency);
         if (!authorized) {
             res.sendStatus(403);

--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -1,5 +1,9 @@
 const { getUser } = require('../db');
 
+function isPartOfAgency(agencies, agencyId) {
+    return agencies.find((s) => s.id === Number(agencyId));
+}
+
 /**
  * Determine if a user is authorized for an agency.
  *
@@ -9,7 +13,7 @@ const { getUser } = require('../db');
  */
 async function isAuthorized(userId, agencyId) {
     const user = await getUser(userId);
-    return user.agency.subagencies.includes(agencyId);
+    return isPartOfAgency(user.agency.subagencies, agencyId);
 }
 
 async function requireAdminUser(req, res, next) {
@@ -83,5 +87,5 @@ async function requireUser(req, res, next) {
 }
 
 module.exports = {
-    requireAdminUser, requireUser, isAuthorized,
+    requireAdminUser, requireUser, isAuthorized, isPartOfAgency,
 };

--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -27,21 +27,9 @@ async function requireAdminUser(req, res, next) {
         res.sendStatus(403);
         return;
     }
+    const paramAgencyId = req.params.organizationId;
 
-    // Depending on the request, an agency ID may be specified in zero or one of:
-    //  a header: angecy-id
-    //  a query string: ?agency=...
-    //  a route parameter :agency
-    //  a route parameter :agencyId
-    //  a body field named 'agency'
-    const headerAgency = req.headers['agency-id'];
-    const queryAgency = req.query.agency;
-    const paramAgency = req.params.agency;
-    const paramAgencyId = req.params.agencyId;
-    // since the body is JSON, agency field will be a number, to keep everything the same type, convert it to a string
-    const bodyAgency = req.body.agency !== undefined && req.body.agency !== null ? req.body.agency.toString() : null;
-
-    const requestAgency = Number(bodyAgency || paramAgency || paramAgencyId || queryAgency || headerAgency);
+    const requestAgency = Number(paramAgencyId);
 
     if (!Number.isNaN(requestAgency)) {
         const authorized = await isAuthorized(req.signedCookies.userId, requestAgency);
@@ -64,7 +52,7 @@ async function requireUser(req, res, next) {
     }
 
     const user = await getUser(req.signedCookies.userId);
-    if (req.query.agency && user.role_name === 'staff') {
+    if (req.params.organizationId && user.role_name === 'staff' && (req.params.organizationId !== user.agency_id.toString())) {
         res.sendStatus(403); // Staff are restricted to their own agency.
         return;
     }

--- a/packages/server/src/lib/access-helpers.js
+++ b/packages/server/src/lib/access-helpers.js
@@ -29,16 +29,19 @@ async function requireAdminUser(req, res, next) {
     }
 
     // Depending on the request, an agency ID may be specified in zero or one of:
-    //  the query string: ?agency=...
+    //  a header: angecy-id
+    //  a query string: ?agency=...
     //  a route parameter :agency
     //  a route parameter :agencyId
     //  a body field named 'agency'
+    const headerAgency = Number(req.headers['agency-id']);
     const queryAgency = Number(req.query.agency);
     const paramAgency = Number(req.params.agency);
     const paramAgencyId = Number(req.params.agencyId);
     const bodyAgency = Number(req.body.agency);
 
     let count = 0;
+    if (!Number.isNaN(headerAgency)) count += 1;
     if (!Number.isNaN(queryAgency)) count += 1;
     if (!Number.isNaN(paramAgency)) count += 1;
     if (!Number.isNaN(paramAgencyId)) count += 1;
@@ -49,7 +52,7 @@ async function requireAdminUser(req, res, next) {
         return;
     } if (count === 1) {
         // Is this user an admin of the specified agency?
-        const requestAgency = queryAgency || paramAgency || paramAgencyId || bodyAgency || 0;
+        const requestAgency = headerAgency || queryAgency || paramAgency || paramAgencyId || bodyAgency || 0;
         const authorized = await isAuthorized(req.signedCookies.userId, requestAgency);
         if (!authorized) {
             res.sendStatus(403);

--- a/packages/server/src/routes/agencies.js
+++ b/packages/server/src/routes/agencies.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const { requireAdminUser, requireUser } = require('../lib/access-helpers');
 const {
     getAgency, getAgencies, setAgencyThresholds,

--- a/packages/server/src/routes/agencies.js
+++ b/packages/server/src/routes/agencies.js
@@ -3,16 +3,16 @@ const express = require('express');
 const router = express.Router();
 const { requireAdminUser, requireUser } = require('../lib/access-helpers');
 const {
-    getAgency, getAgencies, setAgencyThresholds, getUser,
+    getAgency, getAgencies, setAgencyThresholds,
 } = require('../db');
 
 router.get('/', requireUser, async (req, res) => {
-    const user = await getUser(req.signedCookies.userId);
+    const { user } = req.session;
     let response;
     if (user.role.name === 'admin') {
-        response = await getAgencies(req.session.agency);
+        response = await getAgencies(req.session.selectedAgency);
     } else {
-        response = await getAgency(req.session.agency);
+        response = await getAgency(req.session.selectedAgency);
     }
     res.json(response);
 });

--- a/packages/server/src/routes/dashboard.js
+++ b/packages/server/src/routes/dashboard.js
@@ -2,13 +2,14 @@ const express = require('express');
 
 const router = express.Router();
 const db = require('../db');
+const { requireUser } = require('../lib/access-helpers');
 
-router.get('/', async (req, res) => {
+router.get('/', requireUser, async (req, res) => {
     const result = {};
     let agencyCriteria;
 
     if (req.query.totalGrants || req.query.grantsCreatedFromTs || req.query.grantsUpdatedFromTs) {
-        agencyCriteria = await db.getAgencyCriteriaForUserId(req.signedCookies.userId);
+        agencyCriteria = await db.getAgencyCriteriaForAgency(req.session.selectedAgency);
     }
 
     if (req.query.totalGrants) {

--- a/packages/server/src/routes/dashboard.js
+++ b/packages/server/src/routes/dashboard.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const db = require('../db');
 const { requireUser } = require('../lib/access-helpers');
 

--- a/packages/server/src/routes/eligibilityCodes.js
+++ b/packages/server/src/routes/eligibilityCodes.js
@@ -5,12 +5,12 @@ const db = require('../db');
 const { requireAdminUser, requireUser } = require('../lib/access-helpers');
 
 router.get('/', requireUser, async (req, res) => {
-    const elegibilityCodes = await db.getAgencyEligibilityCodes(req.session.agency);
+    const elegibilityCodes = await db.getAgencyEligibilityCodes(req.session.selectedAgency);
     res.json(elegibilityCodes);
 });
 
 router.put('/:code/enable/:value', requireAdminUser, async (req, res) => {
-    const result = await db.setAgencyEligibilityCodeEnabled(req.params.code, req.session.agency, req.params.value === 'true');
+    const result = await db.setAgencyEligibilityCodeEnabled(req.params.code, req.session.selectedAgency, req.params.value === 'true');
     res.json(result);
 });
 

--- a/packages/server/src/routes/eligibilityCodes.js
+++ b/packages/server/src/routes/eligibilityCodes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const db = require('../db');
 const { requireAdminUser, requireUser } = require('../lib/access-helpers');
 

--- a/packages/server/src/routes/grants.js
+++ b/packages/server/src/routes/grants.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const db = require('../db');
 const pdf = require('../lib/pdf');
 const { requireUser, isPartOfAgency } = require('../lib/access-helpers');

--- a/packages/server/src/routes/interestedCodes.js
+++ b/packages/server/src/routes/interestedCodes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const db = require('../db');
 
 router.get('/', async (req, res) => {

--- a/packages/server/src/routes/keywords.js
+++ b/packages/server/src/routes/keywords.js
@@ -9,7 +9,7 @@ router.post('/', requireAdminUser, async (req, res) => {
         search_term: req.body.searchTerm,
         mode: '',
         notes: req.body.notes,
-        agency_id: req.session.agency,
+        agency_id: req.session.selectedAgency,
     });
 
     res.json(result);
@@ -35,7 +35,7 @@ router.delete('/:keywordId', requireAdminUser, async (req, res) => {
 });
 
 router.get('/', requireUser, async (req, res) => {
-    const keywords = await db.getAgencyKeywords(req.session.agency);
+    const keywords = await db.getAgencyKeywords(req.session.selectedAgency);
     res.json(keywords);
 });
 

--- a/packages/server/src/routes/keywords.js
+++ b/packages/server/src/routes/keywords.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const { requireAdminUser, requireUser, isAuthorized } = require('../lib/access-helpers');
 const db = require('../db');
 

--- a/packages/server/src/routes/refresh.js
+++ b/packages/server/src/routes/refresh.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const grantscraper = require('../lib/grantscraper');
 
 router.get('/grants', async (req, res) => {

--- a/packages/server/src/routes/roles.js
+++ b/packages/server/src/routes/roles.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const { requireAdminUser } = require('../lib/access-helpers');
 const db = require('../db');
 

--- a/packages/server/src/routes/sessions.js
+++ b/packages/server/src/routes/sessions.js
@@ -3,7 +3,7 @@ const express = require('express');
 const _ = require('lodash-checkit');
 const { sendPasscode } = require('../lib/email');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const {
     getUser,
     getAccessToken,

--- a/packages/server/src/routes/users.js
+++ b/packages/server/src/routes/users.js
@@ -37,11 +37,10 @@ router.get('/', requireAdminUser, async (req, res) => {
 });
 
 router.delete('/:userId', requireAdminUser, async (req, res) => {
-    // Get agency of user to be deleted.
-    const { agency_id } = req.session.user;
+    const userToDelete = await db.getUser(req.params.userId);
 
-    // Is this admin user authorized for that agency?
-    const authorized = await isAuthorized(req.signedCookies.userId, agency_id);
+    // Is this admin user able to delete a user in their agency
+    const authorized = await isAuthorized(req.signedCookies.userId, userToDelete.agency_id);
     if (!authorized) {
         res.sendStatus(403);
         return;

--- a/packages/server/src/routes/users.js
+++ b/packages/server/src/routes/users.js
@@ -16,7 +16,7 @@ router.post('/', requireAdminUser, async (req, res, next) => {
             email: req.body.email.toLowerCase(),
             name: req.body.name,
             role_id: req.body.role,
-            agency_id: req.session.agency,
+            agency_id: req.session.selectedAgency,
         };
         const result = await db.createUser(user);
         res.json({ user: result });
@@ -32,13 +32,13 @@ router.post('/', requireAdminUser, async (req, res, next) => {
 });
 
 router.get('/', requireAdminUser, async (req, res) => {
-    const users = await db.getUsers(req.session.agency);
+    const users = await db.getUsers(req.session.selectedAgency);
     res.json(users);
 });
 
 router.delete('/:userId', requireAdminUser, async (req, res) => {
     // Get agency of user to be deleted.
-    const { agency_id } = await db.getUser(req.params.userId);
+    const { agency_id } = req.session.user;
 
     // Is this admin user authorized for that agency?
     const authorized = await isAuthorized(req.signedCookies.userId, agency_id);

--- a/packages/server/src/routes/users.js
+++ b/packages/server/src/routes/users.js
@@ -1,6 +1,6 @@
 const express = require('express');
 
-const router = express.Router();
+const router = express.Router({ mergeParams: true });
 const { requireAdminUser, isAuthorized } = require('../lib/access-helpers');
 const { sendWelcomeEmail } = require('../lib/email');
 const db = require('../db');

--- a/yarn.lock
+++ b/yarn.lock
@@ -15044,6 +15044,11 @@ vue-router@^3.5.1:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.5.2.tgz#5f55e3f251970e36c3e8d88a7cd2d67a350ade5c"
   integrity sha512-807gn82hTnjCYGrnF3eNmIw/dk7/GE4B5h69BlyCK9KHASwSloD1Sjcn06zg9fVG4fYH2DrsNBZkpLtb25WtaQ==
 
+vue-select@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/vue-select/-/vue-select-3.16.0.tgz#db2ee2ddf80bd8876ce57738107b8a1a741862f4"
+  integrity sha512-F0x7HXTUc5eq7YSjR0uX77RGA+Yk2+I8aMW+NePyPqRX9OPSiDtKpezFIFhnhxqrOvMh4uVR0jHkXIDmzs6nYQ==
+
 vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.2.tgz#dedf349806f25ceb4e64f3ad7c0a44fba735fcf8"


### PR DESCRIPTION
- Integration test will now use a test database in your local postgres instance instead of the local dev database. You must set POSTGRES_TEST_URL environment variable
- Agency id can be pass through headers to indicate which agency is selected
- users.agency.subagencies now is an array of agency objects and not just an array of ids
- A settings dialog was added to the UI (accessible through app bar user dropdown). User can change the selected agency in the dialog
- The selected agency is stored in local session to remember the selection



USDR admin (rafael.pol@protonmail.com) user can see all users:
<img width="1788" alt="Screen Shot 2021-10-26 at 11 35 04 PM" src="https://user-images.githubusercontent.com/4079507/138995937-81bf84a1-3adf-4aa4-a2d0-6485d288ad33.png">

USDR admin (rafael.pol@protonmail.com) can change to another agency. Only resources from that agency or child agencies are shown:

<img width="1769" alt="Screen Shot 2021-10-26 at 11 34 55 PM" src="https://user-images.githubusercontent.com/4079507/138995976-2362028d-c7ac-4516-ae86-38ff7e04a07c.png">

Health agency admin user (rafael.pol+health-admin@protonmail.com, note that the app bar email change to this user) can only see users from their agency or child agencies:

<img width="1783" alt="Screen Shot 2021-10-26 at 11 38 16 PM" src="https://user-images.githubusercontent.com/4079507/138996070-674623bb-5ada-4993-82b3-8dcc7f5c48a3.png">

Health agency admin user (rafael.pol+health-admin@protonmail.com) can change to another agency if they have access (via assignment or child relationship):

<img width="1313" alt="Screen Shot 2021-10-26 at 11 38 23 PM" src="https://user-images.githubusercontent.com/4079507/138996169-6145a2d0-eb44-4c6d-af43-67e947d82bbf.png">

Health agency admin user (rafael.pol+health-admin@protonmail.com) can change to a child agency and see only resources from that agency:

<img width="1779" alt="Screen Shot 2021-10-26 at 11 42 20 PM" src="https://user-images.githubusercontent.com/4079507/138996277-c61e3eeb-a44b-4129-8cd3-996324099f0d.png">
